### PR TITLE
Added source repository and issue tracker to PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -50,6 +50,12 @@ ArchiveFormats := ".tar.gz",
 ##
 Status := "dev",
 
+SourceRepository := rec( 
+  Type := "git", 
+  URL := "https://github.com/gap-packages/images"
+),
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+
 AbstractHTML   :=  "",
 
 PackageDoc := rec(


### PR DESCRIPTION
This PR adds new optional components from the PackageInfo.g template
(https://github.com/gap-packages/example/blob/master/PackageInfo.g):
- Type and the URL of the source code repository
- URL of the public issue tracker
